### PR TITLE
[Feat] 청년 정책 API 데이터 가공 작업 및 INSERT 기능 개발

### DIFF
--- a/src/main/java/sandbox/apricot/ApricotBatchApplication.java
+++ b/src/main/java/sandbox/apricot/ApricotBatchApplication.java
@@ -2,8 +2,10 @@ package sandbox.apricot;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class ApricotBatchApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/sandbox/apricot/scheduler/PolicyScheduler.java
+++ b/src/main/java/sandbox/apricot/scheduler/PolicyScheduler.java
@@ -1,12 +1,37 @@
 package sandbox.apricot.scheduler;
 
+import java.util.Date;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import sandbox.apricot.youth.dto.response.PolicyDto;
+import sandbox.apricot.youth.service.PolicyService;
 
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class PolicyScheduler {
 
+    private final PolicyService service;
+
+    // @Scheduled(fixedRate = 60000) // 테스트 용도 1분, TODO: 프로젝트 배포 시점 삭제
+    @Scheduled(cron = "0 0 4 * * MON-FRI") // 주중(월요일 ~ 금요일) 새벽 4시에 실행
+    public void schedule() {
+        log.info(" >>> 🔄 청년 정책 데이터 수집 시작");
+
+        List<PolicyDto> policies = service.getPolicies();
+
+        if (policies.isEmpty()) {
+            log.info(" >>> 📉 저장할 새로운 데이터가 없습니다.");
+        } else {
+            log.info(" >>> 📈 {}개의 정책 데이터를 수집하였습니다.", policies.size());
+
+            // 정책 데이터 저장
+            service.savePolicies(policies);
+
+            log.info(" >>> ✅ 청년 정책 데이터 수집 및 데이터베이스 저장 완료 - {}", new Date());
+        }
+    }
 }

--- a/src/main/java/sandbox/apricot/util/AgeInfoMapper.java
+++ b/src/main/java/sandbox/apricot/util/AgeInfoMapper.java
@@ -1,0 +1,42 @@
+package sandbox.apricot.util;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class AgeInfoMapper {
+
+    public static Map<String, Integer> extractAgeRange(String ageInfo) {
+        Map<String, Integer> ageMap = new HashMap<>();
+
+        Pattern pattern1 = Pattern.compile("만\\s*(\\d+)세\\s*~\\s*(\\d+)세");
+        Pattern pattern2 = Pattern.compile("만\\s*(\\d+)세\\s*이상");
+        Pattern pattern3 = Pattern.compile("만\\s*(\\d+)세\\s*~\\s*(\\d+)세\\s*이상");
+        Pattern pattern4 = Pattern.compile("제한없음");
+
+        Matcher matcher1 = pattern1.matcher(ageInfo);
+        Matcher matcher2 = pattern2.matcher(ageInfo);
+        Matcher matcher3 = pattern3.matcher(ageInfo);
+        Matcher matcher4 = pattern4.matcher(ageInfo);
+
+        if (matcher1.find()) {
+            ageMap.put("minAge", Integer.parseInt(matcher1.group(1)));
+            ageMap.put("maxAge", Integer.parseInt(matcher1.group(2)));
+        } else if (matcher2.find()) {
+            ageMap.put("minAge", Integer.parseInt(matcher2.group(1)));
+            ageMap.put("maxAge", null); // 제한 없음
+        } else if (matcher3.find()) {
+            ageMap.put("minAge", Integer.parseInt(matcher3.group(1)));
+            ageMap.put("maxAge", null); // 제한 없음
+        } else if (matcher4.find()) {
+            ageMap.put("minAge", null); // 제한 없음
+            ageMap.put("maxAge", null); // 제한 없음
+        } else {
+            ageMap.put("minAge", 0); // 미정
+            ageMap.put("maxAge", 0); // 미정
+        }
+
+        return ageMap;
+    }
+}

--- a/src/main/java/sandbox/apricot/util/ExtractMapper.java
+++ b/src/main/java/sandbox/apricot/util/ExtractMapper.java
@@ -1,0 +1,38 @@
+package sandbox.apricot.util;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ExtractMapper {
+
+    public static Map<String, String> extractDates(String date) {
+        Map<String, String> dateMap = new HashMap<>();
+
+        // Pattern for YYYY-MM-DD ~ YYYY-MM-DD
+        Pattern pattern1 = Pattern.compile("(\\d{4}-\\d{2}-\\d{2})\\s*~\\s*(\\d{4}-\\d{2}-\\d{2})");
+        // Pattern for YYYY.MM.DD ~ YYYY.MM.DD
+        Pattern pattern2 = Pattern.compile("(\\d{4}\\.\\d{2}\\.\\d{2})\\s*~\\s*(\\d{4}\\.\\d{2}\\.\\d{2})");
+        // Pattern for --DD ~ --DD
+        Pattern pattern3 = Pattern.compile("--(\\d{2})~--(\\d{2})");
+
+        Matcher matcher1 = pattern1.matcher(date);
+        Matcher matcher2 = pattern2.matcher(date);
+        Matcher matcher3 = pattern3.matcher(date);
+
+        if (matcher1.find()) {
+            dateMap.put("policyStartDate", matcher1.group(1));
+            dateMap.put("policyEndDate", matcher1.group(2));
+        } else if (matcher2.find()) {
+            dateMap.put("policyStartDate", matcher2.group(1).replace('.', '-'));
+            dateMap.put("policyEndDate", matcher2.group(2).replace('.', '-'));
+        } else if (matcher3.find()) {
+            dateMap.put("policyStartDate", "--" + matcher3.group(1));
+            dateMap.put("policyEndDate", "--" + matcher3.group(2));
+        }
+
+        return dateMap;
+    }
+
+}

--- a/src/main/java/sandbox/apricot/util/Region.java
+++ b/src/main/java/sandbox/apricot/util/Region.java
@@ -1,0 +1,34 @@
+package sandbox.apricot.util;
+
+import lombok.Getter;
+
+@Getter
+public enum Region {
+    SEOUL("003002001", "서울"),
+    BUSAN("003002002", "부산"),
+    DAEGU("003002003", "대구"),
+    INCHEON("003002004", "인천"),
+    GWANGJU("003002005", "광주"),
+    DAEJEON("003002006", "대전"),
+    ULSAN("003002007", "울산"),
+    GYEONGGI("003002008", "경기"),
+    GANGWON("003002009", "강원"),
+    CHUNGBUK("003002010", "충북"),
+    CHUNGNAM("003002011", "충남"),
+    JEONBUK("003002012", "전북"),
+    JEONNAM("003002013", "전남"),
+    GYEONGBUK("003002014", "경북"),
+    GYEONGNAM("003002015", "경남"),
+    JEJU("003002016", "제주"),
+    SEJONG("003002017", "세종");
+
+    private final String code;
+    private final String name;
+
+    Region(String code, String name) {
+        this.code = code;
+        this.name = name;
+    }
+
+}
+

--- a/src/main/java/sandbox/apricot/youth/dto/response/PolicyDto.java
+++ b/src/main/java/sandbox/apricot/youth/dto/response/PolicyDto.java
@@ -1,0 +1,50 @@
+package sandbox.apricot.youth.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class PolicyDto {
+
+    private String policyCode; // 정책 코드
+    private String categoryCode; // 정책에 속하는 분야 코드
+    private String districtCode; // 지역구
+    private String policyName; // 정책명
+    private String policyContent; // 정책 내용
+    private String supportContent; // 지원 내용
+
+    private String schedule; // TODO: 가공 후 삭제. 일정 -> 정책 시작, 마감일 가공 패턴 찾기
+    private String policyStartDate; // 정책 시작일
+    private String policyEndDate; // 정책 마감일
+
+    private String ageInfo; // TODO: 가공 후 삭제. 연령 정보 가공 패턴 찾기
+    private Integer minAge; // 최소 연령
+    private Integer maxAge; // 최대 연령
+
+    private String majorRqisCn; // 전공 요건 내용
+    private String empmSttsCn; // 취업 상태 내용
+    private String splzRlmRqisCn; // 특별 분야 내용
+    private String accrRqisCn; // 학력 요건 내용
+    private String prcpCn; // 거주지 및 소득 조건 내용
+    private String aditRscn; // 추가 단서 사항 내용
+    private String prcpLmttTrgtCn; // 참여 제한 대상 내용
+    private String rqutProcCn; // 신청 절차 내용
+    private String pstnPaprCn; // 제출 서류 내용
+    private String jdgnPresCn; // 심사 발표 내용
+
+    private String rqutUrla; // 신청 사이트 주소
+    private String rfcSiteUrla1; // 참고 사이트 URL 주소1
+    private String rfcSiteUrla2; // 참고 사이트 URL 주소2
+
+    private String mngtMson; // 주관 부처명
+    private String mngtMrofCherCn; // 주관 부처 담당자 이름
+    private String cherCtpcCn; // 주관 부처 담당자 연락처
+
+    private String cnsgNmor; // 운영 기관명
+    private String tintCherCn; // 운영 기관 담당자 이름
+    private String tintCherCtpcCn; // 운영 기관 담당자 연락처
+
+    private String etct; // 기타 사항
+
+}

--- a/src/main/java/sandbox/apricot/youth/entity/Policy.java
+++ b/src/main/java/sandbox/apricot/youth/entity/Policy.java
@@ -1,0 +1,63 @@
+package sandbox.apricot.youth.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Builder
+@Table(name = "youth_policy_detail")
+@AllArgsConstructor
+public class Policy {
+
+    @Id
+    private String policyCode; // 정책 코드
+
+    private String categoryCode; // 정책에 속하는 분야 코드
+    private String districtCode; // 지역구
+
+    private String policyName; // 정책명
+    @Lob private String policyContent; // 정책 내용
+    @Lob private String supportContent; // 지원 내용
+
+    @Lob private String schedule; // TODO: 가공 후 삭제. 일정 -> 정책 시작, 마감일 가공 패턴 찾기
+    private String policyStartDate; // 정책 시작일
+    private String policyEndDate; // 정책 마감일
+
+    private String ageInfo; // TODO: 가공 후 삭제. 연령 정보 가공 패턴 찾기
+    private Integer minAge; // 최소 연령
+    private Integer maxAge; // 최대 연령
+
+    @Lob private String majorRqisCn; // 전공 요건 내용
+    @Lob private String empmSttsCn; // 취업 상태 내용
+    @Lob private String splzRlmRqisCn; // 특별 분야 내용
+    @Lob private String accrRqisCn; // 학력 요건 내용
+    @Lob private String prcpCn; // 거주지 및 소득 조건 내용
+    @Lob private String aditRscn; // 추가 단서 사항 내용
+    @Lob private String prcpLmttTrgtCn; // 참여 제한 대상 내용
+    @Lob private String rqutProcCn; // 신청 절차 내용
+    @Lob private String pstnPaprCn; // 제출 서류 내용
+    @Lob private String jdgnPresCn; // 심사 발표 내용
+
+    private String rqutUrla; // 신청 사이트 주소
+    private String rfcSiteUrla1; // 참고 사이트 URL 주소1
+    private String rfcSiteUrla2; // 참고 사이트 URL 주소2
+
+    private String mngtMson; // 주관 부처명
+    private String mngtMrofCherCn; // 주관 부처 담당자 이름
+    private String cherCtpcCn; // 주관 부처 담당자 연락처
+
+    private String cnsgNmor; // 운영 기관명
+    private String tintCherCn; // 운영 기관 담당자 이름
+    private String tintCherCtpcCn; // 운영 기관 담당자 연락처
+
+    @Lob private String etct; // 기타 사항
+
+}

--- a/src/main/java/sandbox/apricot/youth/repository/PolicyRepository.java
+++ b/src/main/java/sandbox/apricot/youth/repository/PolicyRepository.java
@@ -1,0 +1,11 @@
+package sandbox.apricot.youth.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import sandbox.apricot.youth.entity.Policy;
+
+public interface PolicyRepository extends JpaRepository<Policy, String> {
+
+    Optional<Policy> findByPolicyCode(String policyCode);
+
+}

--- a/src/main/java/sandbox/apricot/youth/service/PolicyService.java
+++ b/src/main/java/sandbox/apricot/youth/service/PolicyService.java
@@ -1,0 +1,20 @@
+package sandbox.apricot.youth.service;
+
+import java.util.List;
+import sandbox.apricot.youth.dto.response.PolicyDto;
+
+public interface PolicyService {
+
+    /**
+     * OpenAPI 청년 정책 DTO 리스트로 반환합니다.
+     *
+     * @return 정책 데이터 리스트
+     */
+    List<PolicyDto> getPolicies();
+
+    /**
+     * 정책 데이터를 데이터베이스에 저장합니다.
+     */
+    void savePolicies(List<PolicyDto> policies);
+
+}

--- a/src/main/java/sandbox/apricot/youth/service/PolicyServiceImpl.java
+++ b/src/main/java/sandbox/apricot/youth/service/PolicyServiceImpl.java
@@ -1,0 +1,219 @@
+package sandbox.apricot.youth.service;
+
+import static sandbox.apricot.util.Region.SEOUL;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.json.XML;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+import sandbox.apricot.util.AgeInfoMapper;
+import sandbox.apricot.util.ExtractMapper;
+import sandbox.apricot.youth.dto.response.PolicyDto;
+import sandbox.apricot.youth.entity.Policy;
+import sandbox.apricot.youth.repository.PolicyRepository;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class PolicyServiceImpl implements PolicyService {
+
+    @Value("${youth-policy.apikey}")
+    private String apiKey;
+
+    @Value("${youth-policy.default-url}")
+    private String url;
+
+    private final PolicyRepository repository;
+
+    @Override
+    public List<PolicyDto> getPolicies() {
+        List<PolicyDto> allPolicies = new ArrayList<>();
+        int pageIndex = 1;
+        int totalCnt = 0;
+
+        do {
+            // URL, Parameter 빌드
+            int MAX_DISPLAY = 100;
+            String uri = UriComponentsBuilder.fromHttpUrl(url)
+                    .queryParam("pageIndex", pageIndex)
+                    .queryParam("display", MAX_DISPLAY)
+                    .queryParam("openApiVlak", apiKey)
+                    .queryParam("srchPolyBizSecd", SEOUL.getCode())
+                    .toUriString();
+
+            RestTemplate restTemplate = new RestTemplate();
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_XML);
+            HttpEntity<String> entity = new HttpEntity<>(headers);
+
+            ResponseEntity<String> response;
+            try {
+                response = restTemplate.exchange(uri, HttpMethod.GET, entity, String.class);
+            } catch (RestClientException e) {
+                log.error(" >>> ❌ API 호출 오류 및 재시도 실행: {}", e.getMessage());
+                try {
+                    Thread.sleep(5000); // 5s 대기 후 실행
+                    response = restTemplate.exchange(uri, HttpMethod.GET, entity, String.class);
+                } catch (Exception ex) {
+                    log.error(" >>> ❌ API 재호출 실패: {}", ex.getMessage());
+                    return new ArrayList<>(); // TODO: API 호출 실패 Exception 처리
+                }
+            }
+
+            // XML -> JSON
+            String jsonResponse = XML.toJSONObject(Objects.requireNonNull(response.getBody()))
+                    .toString();
+            JSONObject root = new JSONObject(jsonResponse);
+            JSONObject youthPolicyList = root.optJSONObject("youthPolicyList");
+
+            // 총 데이터 수 확인
+            if (totalCnt == 0 && youthPolicyList != null) {
+                totalCnt = youthPolicyList.optInt("totalCnt");
+            }
+
+            List<PolicyDto> policies = parsePolicyData(jsonResponse);
+            allPolicies.addAll(policies);
+
+            pageIndex++;
+        } while (allPolicies.size() < totalCnt);
+
+        return allPolicies;
+    }
+
+    private List<PolicyDto> parsePolicyData(String response) {
+        JSONObject root = new JSONObject(response);
+        JSONObject youthPolicyList = root.optJSONObject("youthPolicyList");
+        if (youthPolicyList == null) {
+            log.error(" >>> ❌ 'youthPolicyList' 객체를 찾을 수 없습니다.");
+            return new ArrayList<>(); // TODO: 실패 Exception 처리
+        }
+
+        JSONArray youthPolicies = youthPolicyList.optJSONArray("youthPolicy");
+        if (youthPolicies == null) {
+            log.error(" >>> ❌ 'youthPolicyList' 객체에서 'youthPolicy' 배열을 찾을 수 없습니다.");
+            return new ArrayList<>(); // TODO: 실패 Exception 처리
+        }
+
+        List<PolicyDto> data = new ArrayList<>();
+        for (int item = 0; item < youthPolicies.length(); item++) {
+            JSONObject policy = youthPolicies.optJSONObject(item);
+
+            String polyBizSecd = policy.optString("polyBizSecd");
+
+            String rqutPrdCn = policy.optString("rqutPrdCn");
+            Map<String, String> dates = ExtractMapper.extractDates(rqutPrdCn);
+
+            Map<String, Integer> ageRange = AgeInfoMapper.extractAgeRange(policy.optString("ageInfo"));
+
+            PolicyDto resDto = PolicyDto.builder()
+                    .policyCode(policy.optString("bizId"))
+                    .categoryCode(policy.optString("polyRlmCd"))
+                    .districtCode(polyBizSecd.substring(polyBizSecd.length() - 2))
+                    .policyName(policy.optString("polyBizSjnm"))
+                    .policyContent(policy.optString("polyItcnCn"))
+                    .supportContent(policy.optString("sporCn"))
+                    .schedule(rqutPrdCn) // TODO: 단어 필터링 지속적인 확인 필요. 추후 삭제될 컬럼.
+                    .policyStartDate(dates.get("policyStartDate"))
+                    .policyEndDate(dates.get("policyEndDate"))
+                    .ageInfo(policy.optString("ageInfo")) // TODO: 단어 필터링 지속적인 확인 필요. 추후 삭제될 컬럼.
+                    .minAge(ageRange.get("minAge"))
+                    .maxAge(ageRange.get("maxAge"))
+                    .majorRqisCn(policy.optString("majorRqisCn"))
+                    .empmSttsCn(policy.optString("empmSttsCn"))
+                    .splzRlmRqisCn(policy.optString("splzRlmRqisCn"))
+                    .accrRqisCn(policy.optString("accrRqisCn"))
+                    .prcpCn(policy.optString("prcpCn"))
+                    .aditRscn(policy.optString("aditRscn"))
+                    .prcpLmttTrgtCn(policy.optString("prcpLmttTrgtCn"))
+                    .rqutProcCn(policy.optString("rqutProcCn"))
+                    .pstnPaprCn(policy.optString("pstnPaprCn"))
+                    .jdgnPresCn(policy.optString("jdgnPresCn"))
+                    .rqutUrla(policy.optString("rqutUrla"))
+                    .rfcSiteUrla1(policy.optString("rfcSiteUrla1"))
+                    .rfcSiteUrla2(policy.optString("rfcSiteUrla2"))
+                    .mngtMson(policy.optString("mngtMson"))
+                    .mngtMrofCherCn(policy.optString("mngtMrofCherCn"))
+                    .cherCtpcCn(policy.optString("cherCtpcCn"))
+                    .cnsgNmor(policy.optString("cnsgNmor"))
+                    .tintCherCn(policy.optString("tintCherCn"))
+                    .tintCherCtpcCn(policy.optString("tintCherCtpcCn"))
+                    .etct(policy.optString("etct"))
+                    .build();
+            data.add(resDto);
+        }
+        return data;
+    }
+
+    @Override
+    public void savePolicies(List<PolicyDto> policies) {
+        if (policies.isEmpty()) {
+            log.info(" >>> ❌ 저장할 데이터가 없습니다.");
+        }
+        for (PolicyDto dto : policies) {
+            try {
+                Optional<Policy> existingPolicy = repository.findById(dto.getPolicyCode());
+
+                if (existingPolicy.isPresent()) {
+                    log.info(" >>> 🔄 중복된 정책 데이터 발견 (저장되지 않음): {}", dto.getPolicyCode());
+                    continue;
+                }
+                Policy policy = Policy.builder()
+                        .policyCode(dto.getPolicyCode())
+                        .categoryCode(dto.getCategoryCode())
+                        .districtCode(dto.getDistrictCode())
+                        .policyName(dto.getPolicyName())
+                        .policyContent(dto.getPolicyContent())
+                        .supportContent(dto.getSupportContent())
+                        .schedule(dto.getSchedule()) // TODO: 단어 필터링 지속적인 확인 필요. 추후 삭제될 컬럼.
+                        .policyStartDate(dto.getPolicyStartDate())
+                        .policyEndDate(dto.getPolicyEndDate())
+                        .ageInfo(dto.getAgeInfo()) // TODO: 단어 필터링 지속적인 확인 필요. 추후 삭제될 컬럼.
+                        .minAge(dto.getMinAge())
+                        .maxAge(dto.getMaxAge())
+                        .majorRqisCn(dto.getMajorRqisCn())
+                        .empmSttsCn(dto.getEmpmSttsCn())
+                        .splzRlmRqisCn(dto.getSplzRlmRqisCn())
+                        .accrRqisCn(dto.getAccrRqisCn())
+                        .prcpCn(dto.getPrcpCn())
+                        .aditRscn(dto.getAditRscn())
+                        .prcpLmttTrgtCn(dto.getPrcpLmttTrgtCn())
+                        .rqutProcCn(dto.getRqutProcCn())
+                        .pstnPaprCn(dto.getPstnPaprCn())
+                        .jdgnPresCn(dto.getJdgnPresCn())
+                        .rqutUrla(dto.getRqutUrla())
+                        .rfcSiteUrla1(dto.getRfcSiteUrla1())
+                        .rfcSiteUrla2(dto.getRfcSiteUrla2())
+                        .mngtMson(dto.getMngtMson())
+                        .mngtMrofCherCn(dto.getMngtMrofCherCn())
+                        .cherCtpcCn(dto.getCherCtpcCn())
+                        .cnsgNmor(dto.getCnsgNmor())
+                        .tintCherCn(dto.getTintCherCn())
+                        .tintCherCtpcCn(dto.getTintCherCtpcCn())
+                        .etct(dto.getEtct())
+                        .build();
+                repository.save(policy);
+            } catch (Exception e) {
+                log.error(" >>> ❌ 데이터 저장 중 오류 발생: {}", e.getMessage());
+            }
+        }
+        log.info(" >>> ✅ 청년 정책 데이터가 데이터베이스에 저장되었습니다.");
+    }
+}


### PR DESCRIPTION
## #️⃣ Relationship Issues
- close: #3 

<br>

## 💡 Key Changes
### 데이터 가공 클래스 생성
- 청년 정책 OpenAPI로 부터 받아온 Return 결과를 살구 서비스에 맞게 사용하도록 가공하는 Mapper 클래스를 개발하였습니다.
- API에서 받아온 결과 값이 String 문자열로 서비스에서 사용하고자 하는 목적과 맞지 않았고, 이를 아래와 같이 가공하였습니다.
1. **📄 AgeInfoMapper.class**
> API로 부터 받아오는 String 문자열은 "만 19세 ~ 만 29세" 와 같이 문자열로서 Retrun 받게 됩니다. 
> 이를 서비스에서 좀 더 핸들링하기 쉽도록 `minAge`, `maxAge`로 변환하도록 처리하는 클래스입니다.
> 가공 방식은 패턴을 지정해서 해당 패턴인 경우 가공하도록 처리하였고, "만 19세 이상" 인 경우에는 `minAge: 19`, `maxAge: null` 로서 데이터베이스에 저장되게 됩니다. 또한 "제한 없음"의 경우 두 컬럼 모두 `null`이 저장되게 됩니다.

2. **📄 ExtractMapper.class** 
> AgeInfo와 동일하게 받아온 문자열을 가공하기 위한 클래스입니다.
> 정책의 시작일과 마감일을 나눠 변환하는 기능을 하고, 시작일과 마감일에 대한 문자열 분석이 필요한데, 결과값을 분석하여 패턴을 알게되면, 해당 클래스에 패턴으로 등록해주시면 됩니다.

<br>

## ➕ ETC 
- 스케줄러 처리는 주중 04:00로 지정하였고, 테스트 결과 의도한 결과가 Database에 저장된 것을 확인 했습니다.
<img width="861" alt="image" src="https://github.com/user-attachments/assets/3cd24597-32be-4a44-8b7c-0a151cc1f792">
