### PR TITLE
[Add] 청년 정책 데이터 컬럼 추가

### DIFF
--- a/src/main/java/sandbox/apricot/scheduler/PolicyScheduler.java
+++ b/src/main/java/sandbox/apricot/scheduler/PolicyScheduler.java
@@ -17,7 +17,7 @@ public class PolicyScheduler {
     private final PolicyService service;
 
     // @Scheduled(fixedRate = 60000) // 테스트 용도 1분, TODO: 프로젝트 배포 시점 삭제
-//    @Scheduled(cron = "0 0 4 * * MON-FRI") // 주중(월요일 ~ 금요일) 새벽 4시에 실행
+    @Scheduled(cron = "0 0 4 * * MON-FRI") // 주중(월요일 ~ 금요일) 새벽 4시에 실행
     public void schedule() {
         log.info(" >>> 🔄 청년 정책 데이터 수집 시작");
 

--- a/src/main/java/sandbox/apricot/util/AgeInfoFormatter.java
+++ b/src/main/java/sandbox/apricot/util/AgeInfoFormatter.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class AgeInfoMapper {
+public class AgeInfoFormatter {
 
     public static Map<String, Integer> extractAgeRange(String ageInfo) {
         Map<String, Integer> ageMap = new HashMap<>();

--- a/src/main/java/sandbox/apricot/util/ExtractFormatter.java
+++ b/src/main/java/sandbox/apricot/util/ExtractFormatter.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class ExtractMapper {
+public class ExtractFormatter {
 
     public static Map<String, String> extractDates(String date) {
         Map<String, String> dateMap = new HashMap<>();

--- a/src/main/java/sandbox/apricot/util/PeriodFormatter.java
+++ b/src/main/java/sandbox/apricot/util/PeriodFormatter.java
@@ -1,0 +1,15 @@
+package sandbox.apricot.util;
+
+public class PeriodFormatter {
+
+    public static String formatPrdRpttSecd(String prdRpttSecd) {
+        return switch (prdRpttSecd) {
+            case "002001" -> "상시";
+            case "002002" -> "연간반복";
+            case "002003" -> "월간반복";
+            case "002004" -> "특정기간";
+            default -> "미정"; // 002005 ...
+        };
+    }
+
+}

--- a/src/main/java/sandbox/apricot/youth/dto/response/PolicyDto.java
+++ b/src/main/java/sandbox/apricot/youth/dto/response/PolicyDto.java
@@ -14,6 +14,7 @@ public class PolicyDto {
     private String policyContent; // 정책 내용
     private String supportContent; // 지원 내용
 
+    private String prdRpttSecd; // 사업 신청 기간 반복 구분 내용
     private String schedule; // TODO: 가공 후 삭제. 일정 -> 정책 시작, 마감일 가공 패턴 찾기
     private String policyStartDate; // 정책 시작일
     private String policyEndDate; // 정책 마감일

--- a/src/main/java/sandbox/apricot/youth/entity/Policy.java
+++ b/src/main/java/sandbox/apricot/youth/entity/Policy.java
@@ -27,6 +27,7 @@ public class Policy {
     @Lob private String policyContent; // 정책 내용
     @Lob private String supportContent; // 지원 내용
 
+    private String prdRpttSecd; // 사업 신청 기간 반복 구분 내용
     @Lob private String schedule; // TODO: 가공 후 삭제. 일정 -> 정책 시작, 마감일 가공 패턴 찾기
     private String policyStartDate; // 정책 시작일
     private String policyEndDate; // 정책 마감일

--- a/src/main/java/sandbox/apricot/youth/repository/PolicyRepository.java
+++ b/src/main/java/sandbox/apricot/youth/repository/PolicyRepository.java
@@ -1,11 +1,7 @@
 package sandbox.apricot.youth.repository;
 
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import sandbox.apricot.youth.entity.Policy;
 
 public interface PolicyRepository extends JpaRepository<Policy, String> {
-
-    Optional<Policy> findByPolicyCode(String policyCode);
-
 }

--- a/src/main/java/sandbox/apricot/youth/service/PolicyServiceImpl.java
+++ b/src/main/java/sandbox/apricot/youth/service/PolicyServiceImpl.java
@@ -23,8 +23,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
-import sandbox.apricot.util.AgeInfoMapper;
-import sandbox.apricot.util.ExtractMapper;
+import sandbox.apricot.util.AgeInfoFormatter;
+import sandbox.apricot.util.ExtractFormatter;
 import sandbox.apricot.util.PeriodFormatter;
 import sandbox.apricot.youth.dto.response.PolicyDto;
 import sandbox.apricot.youth.entity.Policy;
@@ -121,9 +121,9 @@ public class PolicyServiceImpl implements PolicyService {
             String prdRpttSecd = policy.optString("prdRpttSecd");
 
             String rqutPrdCn = policy.optString("rqutPrdCn");
-            Map<String, String> dates = ExtractMapper.extractDates(rqutPrdCn);
+            Map<String, String> dates = ExtractFormatter.extractDates(rqutPrdCn);
 
-            Map<String, Integer> ageRange = AgeInfoMapper.extractAgeRange(policy.optString("ageInfo"));
+            Map<String, Integer> ageRange = AgeInfoFormatter.extractAgeRange(policy.optString("ageInfo"));
 
             PolicyDto resDto = PolicyDto.builder()
                     .policyCode(policy.optString("bizId"))

--- a/src/main/java/sandbox/apricot/youth/service/PolicyServiceImpl.java
+++ b/src/main/java/sandbox/apricot/youth/service/PolicyServiceImpl.java
@@ -25,6 +25,7 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 import sandbox.apricot.util.AgeInfoMapper;
 import sandbox.apricot.util.ExtractMapper;
+import sandbox.apricot.util.PeriodFormatter;
 import sandbox.apricot.youth.dto.response.PolicyDto;
 import sandbox.apricot.youth.entity.Policy;
 import sandbox.apricot.youth.repository.PolicyRepository;
@@ -117,6 +118,7 @@ public class PolicyServiceImpl implements PolicyService {
             JSONObject policy = youthPolicies.optJSONObject(item);
 
             String polyBizSecd = policy.optString("polyBizSecd");
+            String prdRpttSecd = policy.optString("prdRpttSecd");
 
             String rqutPrdCn = policy.optString("rqutPrdCn");
             Map<String, String> dates = ExtractMapper.extractDates(rqutPrdCn);
@@ -130,6 +132,7 @@ public class PolicyServiceImpl implements PolicyService {
                     .policyName(policy.optString("polyBizSjnm"))
                     .policyContent(policy.optString("polyItcnCn"))
                     .supportContent(policy.optString("sporCn"))
+                    .prdRpttSecd(PeriodFormatter.formatPrdRpttSecd(prdRpttSecd)) // 사업 신청 기간 반복 구분 내용
                     .schedule(rqutPrdCn) // TODO: 단어 필터링 지속적인 확인 필요. 추후 삭제될 컬럼.
                     .policyStartDate(dates.get("policyStartDate"))
                     .policyEndDate(dates.get("policyEndDate"))
@@ -182,6 +185,7 @@ public class PolicyServiceImpl implements PolicyService {
                         .policyName(dto.getPolicyName())
                         .policyContent(dto.getPolicyContent())
                         .supportContent(dto.getSupportContent())
+                        .prdRpttSecd(dto.getPrdRpttSecd())
                         .schedule(dto.getSchedule()) // TODO: 단어 필터링 지속적인 확인 필요. 추후 삭제될 컬럼.
                         .policyStartDate(dto.getPolicyStartDate())
                         .policyEndDate(dto.getPolicyEndDate())


### PR DESCRIPTION
## #️⃣ Relationship Issues
- close: #6 

<br>

## 💡 Key Changes
- 사업 신청 기간 반복 구분 코드(`prdRpttSecd`)를 추가.
- 포맷터를 개발하여 기존 코드 번호로 되어 있는 컬럼을 코드 내용으로 변경하여 데이터베이스에 저장.
<img width="171" alt="image" src="https://github.com/user-attachments/assets/ce5a288f-8792-4aee-a413-64e8e26d85c0">

<br>

## ➕ ETC 
- 상시, 연간반복, 월간반복, 특정기간, 미정으로 데이터베이스 업데이트 완료.
- 혜택 리스트 뱃지 개발시 활용